### PR TITLE
docs: fix stale refs, add missing commands, update structure [M138]

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@ tap is a local-first collaboration protocol for parallel AI coding sessions.
 
 ### 1. Protocol Surface
 
-- `commands/`, `hooks/`, `skills/`, `templates/`, `.claude-plugin/`
+- `commands/`, `hooks/`, `skills/`, `templates/`
 - Claude-facing plugin surface and mission/comms workflow helpers
 
 ### 2. Core Transport

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,16 +39,19 @@ tap is a local-first collaboration protocol for parallel AI coding sessions.
 
 ```text
 tap/
-  .claude-plugin/
-  bridges/
-  channels/
-  commands/
-  configs/
-  docs/
-  hooks/
-  scripts/
-  skills/
-  templates/
+  bin/              # CLI entry points
+  bridges/          # Runtime bridge adapters
+  channels/         # MCP server (file-based transport)
+  commands/         # CLI command implementations
+  configs/          # Config examples
+  docs/             # Guides and references
+  examples/         # Real multi-agent collaboration highlights (10 excerpts)
+  hooks/            # Git/session hooks
+  packages/         # Sub-packages
+  scripts/          # Bootstrap and ops scripts
+  skills/           # Agent skill definitions
+  src/              # Core source
+  templates/        # File templates
   README.md
   ARCHITECTURE.md
   CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -114,6 +114,57 @@ npx @hua-labs/tap serve --comms-dir /path/to/comms
 
 For npm installs, `serve` runs the bundled `mcp-server.mjs` entry with `node`. In monorepo or local-dev workflows, tap may fall back to repo-local `.ts` sources, which still require `bun`.
 
+### `bridge <subcommand> [instance]`
+
+Manage bridge connections between runtimes and comms.
+
+```bash
+npx @hua-labs/tap bridge start codex --agent-name myAgent
+npx @hua-labs/tap bridge stop codex
+npx @hua-labs/tap bridge status
+```
+
+### `doctor`
+
+Diagnose config drift, bridge health, managed MCP wiring, and runtime state. Use `--fix` to repair common config drift.
+
+```bash
+npx @hua-labs/tap doctor
+npx @hua-labs/tap doctor --fix
+```
+
+### `dashboard`
+
+Show unified ops dashboard with all instances and bridges.
+
+```bash
+npx @hua-labs/tap dashboard
+```
+
+### `init-worktree`
+
+Set up a new git worktree with tap configuration.
+
+```bash
+npx @hua-labs/tap init-worktree --path ../wt-1 --branch feat/my-feature
+```
+
+### `watch`
+
+Watch the comms directory for changes.
+
+```bash
+npx @hua-labs/tap watch
+```
+
+### `version`
+
+Print the current tap version.
+
+```bash
+npx @hua-labs/tap version
+```
+
 ## Supported Runtimes
 
 | Runtime | Config                  | Bridge                 | Mode               |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @hua-labs/tap
 
+> Current version: **0.5.2**
+
 `tap` is a CLI that turns your repo into a shared workspace for Claude, Codex, and Gemini (experimental) so multiple AI agents can coordinate on the same codebase without custom glue code.
 
 ## Why Would I Use It?
@@ -30,9 +32,9 @@ Gemini support is currently experimental and polling-only.
 
 ### `init`
 
-Initialize the comms directory and `.tap-comms/` state.
+Initialize the comms directory and state.
 
-By default, the comms directory is created inside the current repo at `./tap-comms`.
+By default, the comms directory is created inside the current repo at `./tap-comms` and state is stored in `.tap-state/`.
 
 ```bash
 npx @hua-labs/tap init
@@ -85,16 +87,32 @@ npx @hua-labs/tap doctor
 npx @hua-labs/tap doctor --fix
 ```
 
+### `up`
+
+Start all registered bridge daemons with one command.
+
+```bash
+npx @hua-labs/tap up
+```
+
+### `down`
+
+Stop all running bridges.
+
+```bash
+npx @hua-labs/tap down
+```
+
 ### `serve`
 
-Start the tap-comms MCP server (stdio). Convenience command for running the MCP server locally.
+Start the tap MCP server (stdio). Convenience command for running the MCP server locally.
 
 ```bash
 npx @hua-labs/tap serve
 npx @hua-labs/tap serve --comms-dir /path/to/comms
 ```
 
-For npm installs, `serve` runs the bundled `mcp-server.mjs` entry with `node`. In monorepos or local checkouts, tap may fall back to repo-local `.ts` sources, which still require `bun`.
+For npm installs, `serve` runs the bundled `mcp-server.mjs` entry with `node`. In monorepo or local-dev workflows, tap may fall back to repo-local `.ts` sources, which still require `bun`.
 
 ## Supported Runtimes
 
@@ -122,7 +140,7 @@ npx @hua-labs/tap status --json
   "data": {
     "version": "0.x.y",
     "commsDir": "/path/to/comms",
-    "runtimes": {
+    "instances": {
       "claude": { "status": "active", "bridgeMode": "native-push" },
       "codex": { "status": "configured", "bridgeMode": "app-server" }
     }
@@ -165,6 +183,10 @@ comms/
 ├── findings/       # Out-of-scope discoveries
 ├── handoff/        # Session handoff documents
 ├── retros/         # Retrospectives
+├── letters/        # Agent letters (end-of-session reflections)
+├── logs/           # Operational logs
+├── onboarding/     # Onboarding guides
+├── receipts/       # Read receipts
 └── archive/        # Archived messages
 ```
 
@@ -176,6 +198,17 @@ Each runtime has an adapter that:
 4. **Verifies** — confirms the runtime can read the config
 
 The adapter contract (`RuntimeAdapter`) is the extension point for adding new runtimes.
+
+## Examples — Real Multi-Agent Collaboration
+
+The [`examples/`](examples/) directory contains 10 excerpts from actual AI agent communications across 27 generations of collaborative development. Highlights include:
+
+- [Logic Battle: "Will You Ship Broken Code?"](examples/01-logic-battle-known-broken.md) — A 3:2 vote reversal triggered by a single CEO reframe
+- [Cross-Model Review Catches Root Cause Misdiagnosis](examples/02-cross-model-review-root-cause.md) — Codex fact-checks Claude's hypothesis
+- [Naming Creates Identity](examples/08-naming-creates-identity.md) — How a one-character name shapes an agent's work approach
+- [Files as Interface](examples/10-files-as-interface.md) — How 6,000+ markdown files became an AI organization's memory
+
+See [examples/README.md](examples/README.md) for the full list.
 
 ## Recent Changes
 

--- a/README.md
+++ b/README.md
@@ -124,15 +124,6 @@ npx @hua-labs/tap bridge stop codex
 npx @hua-labs/tap bridge status
 ```
 
-### `doctor`
-
-Diagnose config drift, bridge health, managed MCP wiring, and runtime state. Use `--fix` to repair common config drift.
-
-```bash
-npx @hua-labs/tap doctor
-npx @hua-labs/tap doctor --fix
-```
-
 ### `dashboard`
 
 Show unified ops dashboard with all instances and bridges.


### PR DESCRIPTION
## Summary
- Fix `.tap-comms/` → `.tap-state/` stale state directory reference
- Fix `tap-comms` → `tap` MCP key naming (M123 rename)
- Add missing `up`/`down` commands to README
- Fix `runtimes` → `instances` in JSON output example (state v2)
- Add version badge (0.5.2)
- Update comms directory structure (add `letters/`, `logs/`, `onboarding/`, `receipts/`)
- Update ARCHITECTURE.md repository layout (add `bin/`, `src/`, `examples/`, `packages/`)
- Add Examples section linking to 10 collaboration highlights

## Test plan
- [x] Markdown renders correctly
- [x] Internal links valid (`examples/` paths)
- [x] Cross-checked against monorepo source (`packages/tap-comms/`)
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[M138] [찬]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands: up, down, bridge <subcommand> [instance], dashboard, init-worktree, watch, version

* **Documentation**
  * Updated architecture/layout docs with clearer directory roles and revised repo layout (protocol surface simplified)
  * Revised init and serve guidance for monorepo/local-dev workflows
  * Added "Examples — Real Multi-Agent Collaboration" and expanded comms docs (new subdirs)
  * `status --json` example now uses `instances`

* **Chores**
  * Bumped CLI version to 0.5.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->